### PR TITLE
Typo prevents voting from working

### DIFF
--- a/client/views/posts/post_item.js
+++ b/client/views/posts/post_item.js
@@ -10,7 +10,7 @@ Template.postItem.helpers({
   upvotedClass: function() {
     var userId = Meteor.userId();
     if (userId && !_.include(this.upvoters, userId)) {
-      return 'btn-primary upvoteable';
+      return 'btn-primary upvotable';
     } else {
       return 'disabled';
     }


### PR DESCRIPTION
btn is called "upvoteable" but then the event handler references "upvotable". Voting wasn't working for me and this fixed it :) 
