### PR TITLE
loginButtons aligned properly

### DIFF
--- a/client/views/includes/header.html
+++ b/client/views/includes/header.html
@@ -25,7 +25,7 @@
           {{/if}}
         </ul>
         <ul class="nav pull-right">
-          <li>{{> loginButtons}}</li>
+          <li>{{> loginButtons align="right"}} </li>
         </ul>
       </div>
     </div>


### PR DESCRIPTION
From accounts-ui package:

> If you plan to position the login dropdown in the right edge of the screen, use _{{> loginButtons align="right"}}_ in order to get the dropdown to lay itself out without expanding off the edge of the screen.
